### PR TITLE
fix: set noUnusedLocals to false

### DIFF
--- a/tsconfig-versions/default/tsconfig.json
+++ b/tsconfig-versions/default/tsconfig.json
@@ -15,7 +15,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "noImplicitReturns": true,
-        "noUnusedLocals": true,
+        "noUnusedLocals": false,
         "outDir": "./js",
         "preserveConstEnums": true,
         "sourceMap": true,


### PR DESCRIPTION
There is an ongoing issue with Typescript in which properties retrieved via destructuring do not mark that property as being used. 

https://github.com/Microsoft/TypeScript/issues/11324